### PR TITLE
options extenstion

### DIFF
--- a/jquery.json2html.js
+++ b/jquery.json2html.js
@@ -27,7 +27,7 @@
 		};
 
 		//Extend the options (with defaults)
-		if( options !== undefined ) $.extend(options, _options);
+		if( _options !== undefined ) $.extend(options, _options);
 
 		//Insure that we have the events turned (Required)
 		options.events = true;


### PR DESCRIPTION
shouldn't "_options" instead of "options" be checked against undefined?
